### PR TITLE
Change X32 Flag to N32

### DIFF
--- a/bfd/elfnn-riscv.c
+++ b/bfd/elfnn-riscv.c
@@ -138,10 +138,10 @@
 
 #define RISCV_ELF_WORD_BYTES (1 << RISCV_ELF_LOG_WORD_BYTES)
 
-#define ABI_X32_P(abfd) \
-  ((elf_elfheader (abfd)->e_flags & EF_RISCV_X32) != 0)
+#define ABI_N32_P(abfd) \
+  ((elf_elfheader (abfd)->e_flags & EF_RISCV_N32) != 0)
 
-static bool ABI_X32 = false;
+static bool ABI_N32 = false;
 
 /* The name of the dynamic interpreter.  This is put in the .interp
    section.  */
@@ -1775,7 +1775,7 @@ perform_relocation (const reloc_howto_type *howto,
 
     case R_RISCV_CALL:
     case R_RISCV_CALL_PLT:
-      if ((ARCH_SIZE > 32 || ABI_X32_P(input_bfd))&& !VALID_UTYPE_IMM (RISCV_CONST_HIGH_PART (value)))
+      if ((ARCH_SIZE > 32 || ABI_N32_P(input_bfd))&& !VALID_UTYPE_IMM (RISCV_CONST_HIGH_PART (value)))
 	return bfd_reloc_overflow;
       value = ENCODE_UTYPE_IMM (RISCV_CONST_HIGH_PART (value))
 	      | (ENCODE_ITYPE_IMM (value) << 32);
@@ -3799,7 +3799,7 @@ riscv_merge_arch_attr_info (bfd *ibfd, char *in_arch, char *out_arch)
     return NULL;
 
   /* Checking XLEN.  */
-  if (xlen_out != xlen_in && !ABI_X32_P(ibfd))
+  if (xlen_out != xlen_in && !ABI_N32_P(ibfd))
     {
       _bfd_error_handler
 	(_("error: %pB: ISA string of input (%s) doesn't match "
@@ -3819,7 +3819,7 @@ riscv_merge_arch_attr_info (bfd *ibfd, char *in_arch, char *out_arch)
   if (!riscv_merge_multi_letter_ext (&in, &out))
     return NULL;
 
-  if (xlen_in != xlen_out && !ABI_X32_P(ibfd))
+  if (xlen_in != xlen_out && !ABI_N32_P(ibfd))
     {
       _bfd_error_handler
 	(_("error: %pB: XLEN of input (%u) doesn't match "
@@ -3827,7 +3827,7 @@ riscv_merge_arch_attr_info (bfd *ibfd, char *in_arch, char *out_arch)
       return NULL;
     }
 
-  if (xlen_in != ARCH_SIZE && !ABI_X32_P(ibfd))
+  if (xlen_in != ARCH_SIZE && !ABI_N32_P(ibfd))
     {
       _bfd_error_handler
 	(_("error: %pB: unsupported XLEN (%u), you might be "
@@ -4106,8 +4106,8 @@ _bfd_riscv_elf_merge_private_bfd_data (bfd *ibfd, struct bfd_link_info *info)
   /* Allow linking TSO and non-TSO, and keep the TSO flag.  */
   elf_elfheader (obfd)->e_flags |= new_flags & EF_RISCV_TSO;
 
-  /* Allow linking X32 and non-X32, and keep the X32 flag.  */
-  elf_elfheader (obfd)->e_flags |= new_flags & EF_RISCV_X32;
+  /* Allow linking N32 and non-N32, and keep the N32 flag.  */
+  elf_elfheader (obfd)->e_flags |= new_flags & EF_RISCV_N32;
 
   return true;
 
@@ -4548,7 +4548,7 @@ _bfd_riscv_relax_call (bfd *abfd, asection *sec, asection *sym_sec,
   rvc = rvc && VALID_CJTYPE_IMM (foff);
 
   /* C.J exists on RV32 and RV64, but C.JAL is RV32-only.  */
-  rvc = rvc && (rd == 0 || (rd == X_RA && ARCH_SIZE == 32 && (!ABI_X32_P(abfd))));
+  rvc = rvc && (rd == 0 || (rd == X_RA && ARCH_SIZE == 32 && (!ABI_N32_P(abfd))));
 
   if (rvc)
     {
@@ -5263,7 +5263,7 @@ _bfd_riscv_relax_section (bfd *abfd, asection *sec,
   return ret;
 }
 
-#if ARCH_SIZE == 32 && !ABI_X32
+#if ARCH_SIZE == 32 && !ABI_N32
 # define PRSTATUS_SIZE			204
 # define PRSTATUS_OFFSET_PR_CURSIG	12
 # define PRSTATUS_OFFSET_PR_PID		24
@@ -5433,9 +5433,9 @@ riscv_elf_grok_psinfo (bfd *abfd, Elf_Internal_Note *note)
 static bool
 riscv_elf_object_p (bfd *abfd)
 {
-  ABI_X32 = ABI_X32_P(abfd);
+  ABI_N32 = ABI_N32_P(abfd);
   /* There are only three mach types in RISCV currently.  */
-  if (ABI_X32)
+  if (ABI_N32)
     bfd_default_set_arch_mach (abfd, bfd_arch_riscv, bfd_mach_riscv64x32);
   else if (strcmp (abfd->xvec->name, "elf32-littleriscv") == 0
       	|| strcmp (abfd->xvec->name, "elf32-bigriscv") == 0)

--- a/binutils/readelf.c
+++ b/binutils/readelf.c
@@ -4193,8 +4193,8 @@ decode_RISCV_machine_flags (char *out, unsigned e_flags)
   if (e_flags & EF_RISCV_TSO)
     out = stpcpy (out, ", TSO");
 
-  if (e_flags & EF_RISCV_X32)
-    out = stpcpy (out, ", X32");
+  if (e_flags & EF_RISCV_N32)
+    out = stpcpy (out, ", N32");
 
   switch (e_flags & EF_RISCV_FLOAT_ABI)
     {

--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -289,7 +289,7 @@ riscv_set_tso (void)
 static void
 riscv_set_x32 (void)
 {
-  elf_flags |= EF_RISCV_X32;
+  elf_flags |= EF_RISCV_N32;
 }
 
 /* The linked list hanging off of .subsets_list records all enabled extensions,

--- a/include/elf/riscv.h
+++ b/include/elf/riscv.h
@@ -135,8 +135,8 @@ END_RELOC_NUMBERS (R_RISCV_max)
 /* File uses the TSO model. */
 #define EF_RISCV_TSO 0x0010
 
-/* File uses the X32 model. */
-#define EF_RISCV_X32 0x0020
+/* File uses the N32 model. */
+#define EF_RISCV_N32 0x0020
 
 /* Additional section types.  */
 #define SHT_RISCV_ATTRIBUTES 0x70000003 /* Section holds attributes.  */


### PR DESCRIPTION
Change EF_RISCV_X32 to EF_RISCV_N32

bfd/ChangeLog:

        * elfnn-riscv.c (ABI_X32_P):
        (ABI_N32_P):
        (perform_relocation):
        (riscv_merge_arch_attr_info):
        (_bfd_riscv_elf_merge_private_bfd_data):
        (_bfd_riscv_relax_call):
        (_bfd_riscv_relax_section):
        (riscv_elf_object_p):

binutils/ChangeLog:

        * readelf.c (decode_RISCV_machine_flags):

gas/ChangeLog:

        * config/tc-riscv.c (riscv_set_x32):

include/ChangeLog:

        * elf/riscv.h (EF_RISCV_X32):
        (EF_RISCV_N32):