### PR TITLE
Fix pli value range errors

### DIFF
--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -4028,11 +4028,9 @@ riscv_ip (char *str, struct riscv_cl_insn *ip, expressionS *imm_expr,
 		    case 'b': /* Immediate field for 'pli.b'.  */
 		      my_getExpression (imm_expr, asarg);
 		      check_absolute_expr (ip, imm_expr, false);
-		      if (imm_expr->X_add_number > 127
-			 || imm_expr->X_add_number < -128)
-		      as_bad(_("Improper immediate value for 'pli.b' (%"PRIu64"). "
-			    "(should between -128-127)"),
-			    imm_expr->X_add_number);
+		      if ((unsigned long) imm_expr->X_add_number > 255)
+				as_bad (_("bad value for imm field, "
+				"value must be 0...255"));
 		      ip->insn_opcode |= ENCODE_PLI_B_IMM (imm_expr->X_add_number);
 		      imm_expr->X_op = O_absent;
 		      asarg = expr_parse_end;
@@ -4040,11 +4038,9 @@ riscv_ip (char *str, struct riscv_cl_insn *ip, expressionS *imm_expr,
 		    case 'I': /* Immediate field for 'pli.h/w'.  */
 		      my_getExpression (imm_expr, asarg);
 		      check_absolute_expr (ip, imm_expr, false);
-		      if (imm_expr->X_add_number > 511
-			|| imm_expr->X_add_number < -512)
-		      as_bad (_("Improper immediate value for 'pli.h/w' (%"PRIi64"). "
-				"(shoud between -512-511)"),
-				imm_expr->X_add_number);
+		      if ((unsigned long) imm_expr->X_add_number > 1023)
+				as_bad (_("bad value for imm field, "
+				"value must be 0...1023"));
 		      ip->insn_opcode |= ENCODE_PLI_IMM (imm_expr->X_add_number);
 		      imm_expr->X_op = O_absent;
 		      asarg = expr_parse_end;
@@ -4052,11 +4048,9 @@ riscv_ip (char *str, struct riscv_cl_insn *ip, expressionS *imm_expr,
 		    case 'h': /* Immediate field for 'plui.h'.  */
 		      my_getExpression (imm_expr, asarg);
 		      check_absolute_expr (ip, imm_expr, false);
-		      if (imm_expr->X_add_number > 511
-			 || imm_expr->X_add_number < -512)
-		      as_bad(_("Improper immediate value for 'plui.h' (%"PRIu64"). "
-			    "(should between -512-512)"),
-			    imm_expr->X_add_number);
+		      if ((unsigned long) imm_expr->X_add_number > 1023)
+				as_bad (_("bad value for imm field, "
+				"value must be 0...1023"));
 			  imm_expr->X_add_number <<= RISCV_PIMM_H_BITS;
 		      ip->insn_opcode |= ENCODE_PLUI_H_IMM (imm_expr->X_add_number);
 		      imm_expr->X_op = O_absent;
@@ -4065,11 +4059,9 @@ riscv_ip (char *str, struct riscv_cl_insn *ip, expressionS *imm_expr,
 		    case 'u': /* Immediate field for 'plui.w'.  */
 		      my_getExpression (imm_expr, asarg);
 		      check_absolute_expr (ip, imm_expr, false);
-		      if (imm_expr->X_add_number > 511
-			 || imm_expr->X_add_number < -512)
-		      as_bad(_("Improper immediate value for 'plui.w' (%"PRIu64"). "
-			    "(should between -512-512)"),
-			    imm_expr->X_add_number);
+		      if ((unsigned long) imm_expr->X_add_number > 1023)
+				as_bad (_("bad value for imm field, "
+				"value must be 0...1023"));
 			  imm_expr->X_add_number <<= RISCV_PIMM_BITS;
 		      ip->insn_opcode |= ENCODE_PLUI_IMM (imm_expr->X_add_number);
 		      imm_expr->X_op = O_absent;


### PR DESCRIPTION
Hi Jiawei,
This is Alan from NTHU Pllab. We found that the immediate range for pli (pli.b, pli.h, pli.w) is handled incorrectly—for instance, pli.b allows an immediate of 8, but 0xFF triggers an error. The same issue exists for plui.
Our PR updates the validation so these immediates are accepted as intended. Grateful for your review; please let me know if anything should be adjusted.

Attached is file generate from riscv_ctg, the ACT framework, you can compile with the bash file, and change the build path to your toolchain build path.
[test-pli.zip](https://github.com/user-attachments/files/22880228/test-pli.zip)

Best,
Alan