### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -5,19 +5,24 @@ debuggers, etc., plus their support routines, definitions, and documentation.
 
 If you are receiving this as part of a GDB release, see the file gdb/README.
 If with a binutils release, see binutils/README, and so on. That'll give you
-info about this package -- supported targets, how to use it, how to report
+information about this package -- supported targets, how to use it, how to report
 bugs, etc.
 
 It is now possible to automatically configure and build a variety of
 tools with one command.  To build all of the tools contained herein,
 run the ``configure'' script here, e.g.:
 
+```
 	./configure 
 	make
+```
 
 To install them (by default in /usr/local/bin, /usr/local/lib, etc),
 then do:
+
+```
 	make install
+```
 
 (If the configure script can't determine your type of computer, give it
 the name as an argument, for instance ``./configure sun4''.  You can
@@ -29,19 +34,23 @@ If you have more than one compiler on your system, it is often best to
 explicitly set CC in the environment before running configure, and to
 also set CC when running make.  For example (assuming sh/bash/ksh):
 
+```
 	CC=gcc ./configure
 	make
+```
 
 A similar example using csh:
 
+```
 	setenv CC gcc
 	./configure
 	make
+```
 
 Much of the code and documentation enclosed is copyright by
 the Free Software Foundation, Inc.  See the file COPYING or
 COPYING.LIB in the various directories, for a description of the
 GNU General Public License terms under which you can copy the files.
 
-REPORTING BUGS: Again, see gdb/README, binutils/README, etc., for info
+REPORTING BUGS: Again, see gdb/README, binutils/README, etc., for information
 on where and how to report problems.


### PR DESCRIPTION
Fix “info” to "information" and modify the text format of the command

## Summary by Sourcery

Revise README wording and formatting for clarity

Documentation:
- Replace “info” with “information” throughout the README
- Adjust command text formatting for improved readability