### PR TITLE
Enable process record testsuite for RISC-V

### DIFF
--- a/gdb/testsuite/lib/gdb.exp
+++ b/gdb/testsuite/lib/gdb.exp
@@ -3905,7 +3905,8 @@ proc supports_process_record {} {
          || [istarget "aarch64*-*-linux*"]
 	 || [istarget "loongarch*-*-linux*"]
          || [istarget "powerpc*-*-linux*"]
-         || [istarget "s390*-*-linux*"] } {
+	 || [istarget "s390*-*-linux*"]
+	 || [istarget "riscv*-*-*"] } {
 	return 1
     }
 


### PR DESCRIPTION
When I ran GDB testsuite, I noticed that process record tests are not currently supported on RISC-V. This patch fixes it.

Approved-By: Guinevere Larsen <guinevere@redhat.com>

## Summary by Sourcery

Tests:
- Activate and configure the process record testsuite to run on RISC-V architectures.