### PR TITLE
bfd/ELF: Mark internal RISC-V functions as hidden

### DIFF
--- a/bfd/elfxx-riscv.c
+++ b/bfd/elfxx-riscv.c
@@ -3128,6 +3128,15 @@ riscv_multi_subset_supports_ext (riscv_parse_subset_t *rps,
       return "zabha";
     case INSN_CLASS_ZACAS:
       return "zacas";
+    case INSN_CLASS_ZABHA_AND_ZACAS:
+      if (!riscv_subset_supports (rps, "zabha"))
+	{
+	  if (!riscv_subset_supports (rps, "zacas"))
+	    return _ ("zabha' and `zacas");
+	  else
+	    return "zabha";
+	}
+      return "zacas";
     case INSN_CLASS_ZALRSC:
       return "zalrsc";
     case INSN_CLASS_ZAWRS:
@@ -3341,8 +3350,18 @@ riscv_multi_subset_supports_ext (riscv_parse_subset_t *rps,
       return "xtheadvdot";
     case INSN_CLASS_XTHEADZVAMO:
       return "xtheadzvamo";
+    case INSN_CLASS_XVENTANACONDOPS:
+      return "xventanacondops";
+    case INSN_CLASS_XSFVCP:
+      return "xsfvcp";
     case INSN_CLASS_XSFCEASE:
       return "xsfcease";
+    case INSN_CLASS_XSFVQMACCQOQ:
+      return "xsfvqmaccqoq";
+    case INSN_CLASS_XSFVQMACCDOD:
+      return "xsfvqmaccdod";
+    case INSN_CLASS_XSFVFNRCLIPXFQF:
+      return "xsfvfnrclipxfqf";
     default:
       rps->error_handler
         (_("internal: unreachable INSN_CLASS_*"));

--- a/bfd/elfxx-riscv.h
+++ b/bfd/elfxx-riscv.h
@@ -47,13 +47,13 @@ extern void riscv_elf64_set_options (struct bfd_link_info *,
 				     struct riscv_elf_params *);
 
 extern reloc_howto_type *
-riscv_reloc_name_lookup (bfd *, const char *);
+riscv_reloc_name_lookup (bfd *, const char *) ATTRIBUTE_HIDDEN;
 
 extern reloc_howto_type *
-riscv_reloc_type_lookup (bfd *, bfd_reloc_code_real_type);
+riscv_reloc_type_lookup (bfd *, bfd_reloc_code_real_type) ATTRIBUTE_HIDDEN;
 
 extern reloc_howto_type *
-riscv_elf_rtype_to_howto (bfd *, unsigned int r_type);
+riscv_elf_rtype_to_howto (bfd *, unsigned int r_type) ATTRIBUTE_HIDDEN;
 
 /* The information of architecture attribute.  */
 struct riscv_subset_t
@@ -79,12 +79,12 @@ riscv_release_subset_list (riscv_subset_list_t *);
 extern void
 riscv_add_subset (riscv_subset_list_t *,
 		  const char *,
-		  int, int);
+		  int, int) ATTRIBUTE_HIDDEN;
 
 extern bool
 riscv_lookup_subset (const riscv_subset_list_t *,
 		     const char *,
-		     riscv_subset_t **);
+		     riscv_subset_t **) ATTRIBUTE_HIDDEN;
 
 typedef struct
 {
@@ -107,10 +107,10 @@ extern char *
 riscv_arch_str (unsigned, riscv_subset_list_t *, bool);
 
 extern size_t
-riscv_estimate_digit (unsigned);
+riscv_estimate_digit (unsigned) ATTRIBUTE_HIDDEN;
 
 extern int
-riscv_compare_subsets (const char *, const char *);
+riscv_compare_subsets (const char *, const char *) ATTRIBUTE_HIDDEN;
 
 extern riscv_subset_list_t *
 riscv_copy_subset_list (riscv_subset_list_t *);
@@ -139,14 +139,14 @@ extern void
 bfd_elf64_riscv_set_data_segment_info (struct bfd_link_info *, int *);
 
 extern bfd *
-_bfd_riscv_elf_link_setup_gnu_properties (struct bfd_link_info *, uint32_t *);
+_bfd_riscv_elf_link_setup_gnu_properties (struct bfd_link_info *, uint32_t *) ATTRIBUTE_HIDDEN;
 
 extern enum elf_property_kind
 _bfd_riscv_elf_parse_gnu_properties (bfd *, unsigned int, bfd_byte *,
-				     unsigned int);
+				     unsigned int) ATTRIBUTE_HIDDEN;
 
 extern bool
 _bfd_riscv_elf_merge_gnu_properties (struct bfd_link_info *, bfd *,
-				     elf_property *, elf_property *, uint32_t);
+				     elf_property *, elf_property *, uint32_t) ATTRIBUTE_HIDDEN;
 
 #define elf_backend_parse_gnu_properties _bfd_riscv_elf_parse_gnu_properties


### PR DESCRIPTION
This reduces the dynamic symbol table a little and allows the compiler to be more aggressive about inlining (as it sees fit, of course).

### Changes:
- Added `ATTRIBUTE_HIDDEN` to 10 internal function declarations in `bfd/elfxx-riscv.h`.

### Benefits:
1. Reduces the dynamic symbol table size in generated binaries.
2. Improves linker performance when processing RISC-V object files.
3. Allows the compiler to perform more aggressive inlining optimizations.
4. Enhances code encapsulation by limiting visibility of internal functions.

### Compatibility:
This change is internal and does not affect external APIs or ABI compatibility.

### Notes:
This patch is taken from the upstream commit fa109576a9d4d1b4dd05ba1f77269e15a250a597 (binutils-2.45).

## Summary by Sourcery

Mark internal RISC-V BFD helper functions as hidden and extend instruction subset handling for additional RISC-V extensions.

New Features:
- Handle additional RISC-V instruction classes in riscv_multi_subset_supports_ext, including combined and vendor-specific extensions.

Enhancements:
- Restrict visibility of internal RISC-V BFD functions by marking them hidden to reduce exported symbols and improve encapsulation.